### PR TITLE
fix for duplicate protocol when provided a host arg with protocol

### DIFF
--- a/clients/server/token-sockjs-ws.js
+++ b/clients/server/token-sockjs-ws.js
@@ -214,6 +214,9 @@ var TokenSocket = function(options, actions){
 
   var parsed = url.parse(options.host);
   options.protocol = parsed.protocol === "https:" ? "https:" : "http:";
+  if (parsed.protocol) {
+    options.host = parsed.host;
+  }
 
   if(!options.port){
     var parts = options.host.split(":");

--- a/test/server/unit.js
+++ b/test/server/unit.js
@@ -51,7 +51,7 @@ module.exports = function(TokenSocket, mocks){
 				assert.doesNotThrow(function(){
 					var socket = new TokenSocket({ host: 'http://foo.com'	});
 					var req = socket._rest._requests.shift();
-					assert.isNotOk(req.options.host.includes('http'), 'parsed host does not include protocol');
+					assert.isOk(req.options.host.indexOf('http') === -1, 'parsed host does not include protocol');
 				}, "Constructor does not create an invalid url when passed a host argument that includes protocol");
 			});
 			

--- a/test/server/unit.js
+++ b/test/server/unit.js
@@ -46,7 +46,15 @@ module.exports = function(TokenSocket, mocks){
 				assert.property(socketReq, "token", "Socket auth request has token property");
 				assert.equal(socketReq.token, token, "Socket auth request has correct token");
 			});
-
+			
+			it("Should create a valid socket URL when passed a host argument that includes protocol", function(){
+				assert.doesNotThrow(function(){
+					var socket = new TokenSocket({ host: 'http://foo.com'	});
+					var req = socket._rest._requests.shift();
+					assert.isNotOk(req.options.host.includes('http'), 'parsed host does not include protocol');
+				}, "Constructor does not create an invalid url when passed a host argument that includes protocol");
+			});
+			
 			it("Should not throw an error when created with all possible arguments", function(done){
 				assert.doesNotThrow(function(){
 					var socket = new TokenSocket({


### PR DESCRIPTION
When provided a `host` argument that includes protocol (`'http:'` or `'https:'`), the protocol is extracted via `URL.parse` and inserted into `options.protocol`. The `options.host` is not modified and still includes the original protocol. Thus, when the SockJS object is created with `_opts.protocol + _opts.host + ':' + _opts.port + _opts.path`. This ends up duplicating the protocol in the SockJS argument creating an invalid URL.

Example:
Host argument passed is `http://foo.com`.
When `URL.parse` is called, the `parsed` object contains a `protocol` of value `http:` and `host` of value `foo.com`. The `protocol` of `http:` is stored in `options.protocol` and `options.host` remains `http://foo.com`. Thus when the sockJS object is created, the URL string passed ends up being `http://http://foo.com`.

Fix:
If the `parsed` object from `URL.parse` includes a `protocol`, in addition to storing the `protocol` in `options.protocol`, also store the `parsed.host` in `options.host` effectively removing the protocol from the `options.host` string.