### PR TITLE
Allow passing headers to the initial Token fetch in node

### DIFF
--- a/clients/server/token-sockjs-ws.js
+++ b/clients/server/token-sockjs-ws.js
@@ -37,7 +37,8 @@ Monitor.prototype.sendMessage = function(data, callback){
 Monitor.prototype.handleResponse = function(data){
   var fn = null;
   if(data.rpc && data.uuid)
-    fn = this._inTransit[data.rpc][data.uuid];
+    // Throws an error if a response is invalid.
+    if(this._inTransit[data.rpc]) fn = this._inTransit[data.rpc][data.uuid];
   if(fn && typeof fn === "function"){
     if(data.error)
       fn(data.error);

--- a/clients/server/token-sockjs-ws.js
+++ b/clients/server/token-sockjs-ws.js
@@ -261,6 +261,7 @@ var TokenSocket = function(options, actions){
     method: "GET",
     protocol: options.protocol,
     host: options.host,
+    headers: options.headers || {},
     path: self._tokenPath,
     port: options.port
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-sockjs-client",
-  "version": "3.0.2",
+  "version": "3.1.1",
   "description": "Client libraries for Node-Token-Sockjs server",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This module doesn't work in node, in certain environments, where you use Cookie Authentication (or probably any type of authentication) to return a token for the later SockJS module to use.

This introduces the ability to pass headers to that initial call via `options.headers`.

Also fixes `handleResponse` to not throw an error in cases when there is no rpc specified, or we don't know about that rpc.